### PR TITLE
Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+# https://github.com/anaconda/docker-images
+FROM continuumio/miniconda3
+
+# Set the working directory in the container
+WORKDIR /src
+
+# Install unzip
+RUN apt-get update && apt-get install -y unzip
+
+# Create and activate the environment
+COPY lhasa.yml /src/
+RUN conda env create --file lhasa.yml
+
+RUN echo "source activate lhasa" > ~/.bashrc
+ENV PATH /opt/conda/envs/lhasa/bin:$PATH
+
+# Download and unzip static.zip
+RUN wget https://gpm.nasa.gov/sites/default/files/data/landslides/static.zip -O /tmp/static.zip && \
+    unzip /tmp/static.zip && \
+    rm /tmp/static.zip
+
+# Download and unzip exposure.zip
+RUN wget https://gpm.nasa.gov/sites/default/files/data/landslides/exposure.zip -O /tmp/exposure.zip && \
+    unzip /tmp/exposure.zip && \
+    rm /tmp/exposure.zip
+
+# Download and unzip ref_data.zip
+RUN wget https://gpm.nasa.gov/sites/default/files/data/landslides/ref_data.zip -O /tmp/ref_data.zip && \
+    unzip /tmp/ref_data.zip -d pfdf && \
+    rm /tmp/ref_data.zip
+
+# Necessary directories/files
+RUN mkdir imerg && mkdir smap
+RUN touch ~/.urs_cookies && touch ~/.dodsrc
+RUN echo "HTTP.NETRC=~/.netrc" >> ~/.dodsrc && \
+    echo "HTTP.COOKIEJAR=~/.urs_cookies" >> ~/.dodsrc
+
+# Copy LHASA model and script
+COPY lhasa.py model.json /src/
+
+# Set the entrypoint; write all files to the output directory (volume)
+ENTRYPOINT ["python", "lhasa.py", "--output_path=output"]

--- a/README.md
+++ b/README.md
@@ -62,6 +62,34 @@ After cloning this repository, some setup is required prior to running LHASA. Th
     # Configure authorization for post-fire debris flow model
     python pfdf/scripts/make_netrc.py
 
+#### Docker
+
+To run LHASA with Docker, create the `.netrc` file at the root of the project, with following
+content:
+
+```plaintext
+machine urs.earthdata.nasa.gov login <uid> password <password>
+machine jsimpsonhttps.pps.eosdis.nasa.gov login <email> password <email>
+```
+
+Replace `<uid>`, `<password>` and `<email>` with your login credentials.
+Build the image:
+
+```bash
+docker compose build
+```
+
+Run LHASA with:
+
+```bash
+docker compose run --rm lhasa
+```
+
+> [!NOTE]
+> You can pass arguments to LHASA. For example: `docker compose run --rm lhasa -icd 2 -scd 2 -t 4 -st 10`
+
+For convenience, the resulting files are written to `output/`, which is a volume accessible both on the host machine and the container.
+
 ### Routine operation
 
 Run [lhasa.sh](https://github.com/nasa/LHASA/blob/master/lhasa.sh) at the desired cadence, e.g. once per day. 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,12 @@
+services:
+  lhasa:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./.netrc:/root/.netrc:ro
+      # automatically creates the directories if they don't exist on the host
+      - ./output/nrt/hazard/tif:/src/output/nrt/hazard/tif
+      - ./output/nrt/exposure/csv:/src/output/nrt/exposure/csv
+      - ./output/fcast/hazard/tif:/src/output/fcast/hazard/tif
+      - ./output/fcast/exposure/csv:/src/output/fcast/exposure/csv

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,3 +10,4 @@ services:
       - ./output/nrt/exposure/csv:/src/output/nrt/exposure/csv
       - ./output/fcast/hazard/tif:/src/output/fcast/hazard/tif
       - ./output/fcast/exposure/csv:/src/output/fcast/exposure/csv
+      - ./output:/src/output  # make all results visible on the host


### PR DESCRIPTION
Following PR #27, here are the specific changes for a setup with Docker.

## Docker

For an OS-agnostic setup with Docker, following changes were made:

* Added a `Dockerfile` to create a Docker image for LHASA, including the installation of necessary dependencies and the setup of the environment.
* Introduced a `docker-compose.yaml` file to facilitate the use of Docker Compose for managing the LHASA service and its volumes.
* Described the usage in the `README.md`
